### PR TITLE
Fix for issue #31

### DIFF
--- a/discord/ext/ipcx/client.py
+++ b/discord/ext/ipcx/client.py
@@ -3,8 +3,9 @@ import logging
 from typing import Any, Optional
 
 import aiohttp
+from aiohttp.http_websocket import WSCloseCode
 
-from .errors import NotConnectedError
+from .errors import NotConnectedError, WebSocketClosedError
 
 log = logging.getLogger(__name__)
 
@@ -150,5 +151,13 @@ class Client:
                 await asyncio.sleep(5)
 
                 return await self.request(endpoint, **kwargs)
+
+            if recv.type == aiohttp.WSMsgType.CLOSE:
+                close_code = recv.data
+                reason = WSCloseCode(close_code).name
+
+                raise WebSocketClosedError(
+                    f"WebSocket connection unexpectedly closed with code: {close_code} ({reason})"
+                )
 
             return recv.json()

--- a/discord/ext/ipcx/errors.py
+++ b/discord/ext/ipcx/errors.py
@@ -19,3 +19,7 @@ class JSONEncodeError(IPCError):
 
 class NotConnectedError(IPCError):
     """Raised upon websocket not connected"""
+
+
+class WebSocketClosedError(IPCError):
+    """Raised upon websocket being closed"""

--- a/discord/ext/ipcx/server.py
+++ b/discord/ext/ipcx/server.py
@@ -72,8 +72,6 @@ class Server:
         Turn multicasting on/off. Defaults to True
     multicast_port: int
         The port to run the multicasting server on. Defaults to 20000
-    max_msg_size: Optional[int]
-        The maximum message size in bytes. Defaults to None
     """
 
     ROUTES = {}
@@ -86,7 +84,6 @@ class Server:
         secret_key: Optional[str] = None,
         do_multicast: bool = True,
         multicast_port: int = 20000,
-        max_msg_size: int | None = None,
     ):
         self.bot = bot
         self.loop = bot.loop
@@ -101,8 +98,6 @@ class Server:
 
         self.do_multicast = do_multicast
         self.multicast_port = multicast_port
-
-        self.max_msg_size = max_msg_size
 
         self.endpoints = {}
 
@@ -142,7 +137,7 @@ class Server:
         """
         self.update_endpoints()
 
-        websocket = aiohttp.web.WebSocketResponse(max_msg_size=self.max_msg_size)
+        websocket = aiohttp.web.WebSocketResponse(max_msg_size=0)
         await websocket.prepare(request)
 
         async for message in websocket:


### PR DESCRIPTION
Fixes No767/discord-ext-ipcx#31

Allows specifying `max_msg_size` when starting `ipcx.Server` and sets the default to `None`, which, considering the context, makes the most sense (if someone wants to limit the allowed size for whatever reason, maybe limit bandwidth usage, they can, but I think it makes more sense for the file size not to affect the outcome of an IPC request). Also make the errors more useful by raising `websocket.exception()` if the message type is an error (not only a close error) on the server side (example: `aiohttp.http_websocket.WebSocketError: Message size 4339841 exceeds limit 4194304`), and raising `WebSocketClosedError` with a message containing the code and reason, smth like: `discord.ext.ipcx.errors.WebSocketClosedError: WebSocket connection unexpectedly closed with code: 1009 (MESSAGE_TOO_BIG)` on the client side (if it's a close error).