### PR TITLE
Remove unnecessary imports with `__init__.py` module

### DIFF
--- a/changelog.d/54.bugfix.md
+++ b/changelog.d/54.bugfix.md
@@ -1,0 +1,1 @@
+Remove unnecessary imports with  module

--- a/changelog.d/54.bugfix.md
+++ b/changelog.d/54.bugfix.md
@@ -1,1 +1,1 @@
-Remove unnecessary imports with  module
+Remove unnecessary imports within `__init__.py` module

--- a/discord/ext/ipcx/__init__.py
+++ b/discord/ext/ipcx/__init__.py
@@ -34,4 +34,4 @@ version_info = VersionInfo(major=0, minor=2, micro=2, releaselevel="final")
 
 # Since this class is always exported, we just want to delete it at the end
 # So others can't use it
-del VersionInfo
+del VersionInfo, Literal, NamedTuple


### PR DESCRIPTION
# Summary

<!-- What is this pull request for? Does it fix any issues? -->
Removes `Literal` and `NamedTuple` so later on it's not imported by default magically

## Types of changes

What types of changes does your code introduce to discord-ext-ipcx?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] I have generated news fragments for this PR. (if appropriate, format is {#PR}.type.md)
- [x] This PR does **not** address a duplicate issue or PR
