### PR TITLE
Implement `async with x` operations for `discord.ext.ipcx.Client`

### DIFF
--- a/changelog.d/56.feature.md
+++ b/changelog.d/56.feature.md
@@ -1,0 +1,1 @@
+Implement `async with x` operations for `discord.ext.ipcx.Client`

--- a/discord/ext/ipcx/client.py
+++ b/discord/ext/ipcx/client.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
+
 import asyncio
 import logging
-from typing import Any, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 import aiohttp
 
@@ -9,17 +10,18 @@ from .errors import NotConnectedError
 
 if TYPE_CHECKING:
     from types import TracebackType
+
     from typing_extensions import Self
-    
+
 log = logging.getLogger(__name__)
 
 
 class Client:
     """
     Handles webserver side requests to the bot process.
-    
+
     Operations with ``async with`` will automatically initialize the client and automatically cleans up.
-    
+
     Parameters
     ----------
     host: str
@@ -52,14 +54,19 @@ class Client:
         return "ws://{0.host}:{1}".format(
             self, self.port if self.port else self.multicast_port
         )
-    
+
     async def __aenter__(self) -> Self:
         await self._get_session()
         return self
-    
-    async def __aexit__(self, exc_type: Optional[type[BaseException]], exc_value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
         await self.close()
-    
+
     async def _get_session(self) -> aiohttp.ClientSession:
         if not self.session:
             self.session = aiohttp.ClientSession()

--- a/discord/ext/ipcx/client.py
+++ b/discord/ext/ipcx/client.py
@@ -1,18 +1,25 @@
+from __future__ import annotations
 import asyncio
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 
 import aiohttp
 
 from .errors import NotConnectedError
 
+if TYPE_CHECKING:
+    from types import TracebackType
+    from typing_extensions import Self
+    
 log = logging.getLogger(__name__)
 
 
 class Client:
     """
     Handles webserver side requests to the bot process.
-
+    
+    Operations with ``async with`` will automatically initialize the client and automatically cleans up.
+    
     Parameters
     ----------
     host: str
@@ -38,13 +45,25 @@ class Client:
         self.port = port
         self.multicast_port = multicast_port
 
-        self.session = None
+        self.session: Optional[aiohttp.ClientSession] = None
 
     @property
     def url(self):
         return "ws://{0.host}:{1}".format(
             self, self.port if self.port else self.multicast_port
         )
+    
+    async def __aenter__(self) -> Self:
+        await self._get_session()
+        return self
+    
+    async def __aexit__(self, exc_type: Optional[type[BaseException]], exc_value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
+        await self.close()
+    
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if not self.session:
+            self.session = aiohttp.ClientSession()
+        return self.session
 
     async def close(self) -> None:
         """Properly closes the :class:`aiohttp.ClientSession` session used for connections
@@ -57,11 +76,6 @@ class Client:
         """
         if self.session:
             await self.session.close()
-
-    async def _get_session(self) -> aiohttp.ClientSession:
-        if not self.session:
-            self.session = aiohttp.ClientSession()
-        return self.session
 
     async def get_port(self) -> int:
         """Attempts to obtain the provided port.


### PR DESCRIPTION
# Summary

This PR implements the `async with x` operations for `discord.ext.ipcx.Client`. This would make it easier and more modern in order to start up the client, and is designed to be used with [FastAPI's lifespan events](https://fastapi.tiangolo.com/advanced/events/). This also work with other frameworks that do something similar

## Types of changes

What types of changes does your code introduce to discord-ext-ipcx?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] I have generated news fragments for this PR. (if appropriate, format is {#PR}.type.md)
- [x] This PR does **not** address a duplicate issue or PR
