### PR TITLE
Delist `discord.ext.ipcx.Client.get_port` from public methods

### DIFF
--- a/changelog.d/60.breaking.md
+++ b/changelog.d/60.breaking.md
@@ -1,0 +1,1 @@
+Delist `discord.ext.ipcx.Client.get_port` from public methods

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,9 +17,3 @@ Server
      :members:
      
 ..  autofunction:: discord.ext.ipcx.route
-
-Exceptions
-----------
-
-.. automodule:: discord.ext.ipcx.errors
-     :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,3 +17,9 @@ Server
      :members:
      
 ..  autofunction:: discord.ext.ipcx.route
+
+Exceptions
+----------
+
+.. automodule:: discord.ext.ipcx.errors
+     :members:


### PR DESCRIPTION
# Summary

Basically as `discord.ext.ipcx.Client.get_port` is not used publically, it would be better to hide it as a private undocumented method. This should fully work without issues.

## Types of changes

What types of changes does your code introduce to discord-ext-ipcx?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] I have generated news fragments for this PR. (if appropriate, format is {#PR}.type.md)
- [x] This PR does **not** address a duplicate issue or PR
