### PR TITLE
Include exceptions within API reference

### DIFF
--- a/changelog.d/61.doc.md
+++ b/changelog.d/61.doc.md
@@ -1,0 +1,1 @@
+Include exceptions within API reference

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,3 +17,9 @@ Server
      :members:
      
 ..  autofunction:: discord.ext.ipcx.route
+
+Exceptions
+----------
+
+.. automodule:: discord.ext.ipcx.errors
+     :members:


### PR DESCRIPTION
# Summary

Previous exceptions were not documented, so this is a change in order to have them documented instead.

## Types of changes

What types of changes does your code introduce to discord-ext-ipcx?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [ ] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] I have generated news fragments for this PR. (if appropriate, format is {#PR}.type.md)
- [x] This PR does **not** address a duplicate issue or PR
